### PR TITLE
update regex

### DIFF
--- a/commit-msg
+++ b/commit-msg
@@ -14,7 +14,7 @@ if echo "$commitTitle" | grep -qE "^Merge branch \'"; then
 fi
 
 # check semantic versioning scheme
-if ! echo "$commitTitle" | grep -qE '^(?:feat|fix|docs|style|refactor|perf|test|chore)\((?:\w+|\s|\-|_)+\):'; then
+if ! echo "$commitTitle" | grep -qE '^(?:feat|fix|docs|style|refactor|perf|test|chore)\(?(?:\w+|\s|\-|_)?\)?:\s\w+'; then
 	echo "Your commit title did not follow semantic versioning: $commitTitle"
 	echo "Please see https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commit-message-format"
 	exit 1


### PR DESCRIPTION
Regex does not match most typical commit message `chore: foo` it does match `chore(bar): foo`