### PR TITLE
feat(regex): add more validations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,85 @@
+# Changelog
+
+## 2023-12-24
+
+- always require a valid type (do not allow this anymore: 'myscope: my message' or ': myscope: test'
+  - https://www.conventionalcommits.org/en/v1.0.0/#specification (1)
+
+- add all valid semantic versioning types (build, ci, revert)
+  - https://github.com/conventional-changelog/commitlint/blob/master/%40commitlint/config-conventional/index.js#L22
+
+- allow more characters in the scope (example: 'feat(my-scope, other-scope): my message')
+  - https://github.com/conventional-changelog/commitlint/blob/master/%40commitlint/rules/src/scope-enum.test.ts#L11
+
+- allow optional exclamation mark before the colon to indicate a breaking change (example: 'feat(api)!: changed endpoint for travel times')
+  - https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope-and--to-draw-attention-to-breaking-change
+
+- tested the regex on https://regex101.com with these values:
+
+```
+===== Valid commit messages: =====
+build: my message
+chore: my message
+ci: my message
+docs: my message
+feat: my message
+fix: my message
+perf: my message
+refactor: my message
+revert: my message
+style: my message
+test: my message
+build(my-scope): my message
+chore(my-scope): my message
+ci(my-scope): my message
+docs(my-scope): my message
+feat(my-scope): my message
+fix(my-scope): my message
+perf(my-scope): my message
+refactor(my-scope): my message
+revert(my-scope): my message
+style(my-scope): my message
+test(my-scope): my message
+feat(my-scope, other-scope): my message
+feat(my_scope): my message
+feat(my_scope): MY MESSAGE
+feat(my_scope)!: MY MESSAGE
+
+===== Valid commit message examples from https://www.conventionalcommits.org/en/v1.0.0/#examples: =====
+feat: allow provided config object to extend other configs
+feat!: send an email to the customer when a product is shipped
+feat(api)!: send an email to the customer when a product is shipped
+chore!: drop support for Node 6
+docs: correct spelling of CHANGELOG
+feat(lang): add Polish language
+fix: prevent racing of requests
+revert: let us never again speak of the noodle incident
+
+===== Invalid commit messages: =====
+feat:my message (no space after the colon)
+feat : my message (additional space not allowed)
+ feat: my message (starting space not allowed)
+feat!(scope): my message (exclamation mark for blocking change should be right behind the colon)
+feat(!scope): my message (exclamation mark for blocking change should be right behind the colon)
+feat(scope!): my message (exclamation mark for blocking change should be right behind the colon)
+feat(scope):! my message (exclamation mark for blocking change should be right behind the colon)
+: myscope my message (no type)
+: myscope::: my message (no type)
+: my message (no type)
+myscope: my message (invalid type)
+myscope: my message (invalid type)
+FEAT(my-scope): my message (only lowercase allowed for type)
+feat(MY-SCOPE): my message (only lowercase allowed for scope)
+```
+
+## 2023-05-01
+
+- fix: Fix vs code merges
+
+## 2019-05-27
+
+- updated regex
+
+## 2019-05-20
+
+- initial

--- a/commit-msg
+++ b/commit-msg
@@ -14,8 +14,16 @@ if echo "$commitTitle" | grep -qE "Merge branch"; then
 fi
 
 # check semantic versioning scheme
-if ! echo "$commitTitle" | grep -qE '^(?:|feat|fix|docs|style|refactor|perf|test|chore)\(?(?:\w+|\s|\-|_)?\)?:\s\w+'; then
-	echo "Your commit title did not follow semantic versioning: $commitTitle"
-	echo "Please see https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commit-message-format"
+if ! echo "$commitTitle" | grep -qE '^(feat|fix|docs|style|refactor|perf|test|chore|build|ci|revert)(\([a-z0-9\s\-\_\,]+\))?!?:\s\w'; then
+	echo "Your commit message did not follow semantic versioning: $commitTitle"
+	echo ""
+	echo "Format:   <type>(<optional-scope>): <subject>"
+	echo "Example:  feat(api): add endpoint"
+	echo ""
+	echo "Valid types: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test"
+	echo ""
+	echo "Please see"
+	echo "- https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commit-message-format"
+	echo "- https://www.conventionalcommits.org/en/v1.0.0/#summary"
 	exit 1
 fi


### PR DESCRIPTION
Nice commit hook you have made! :)

This was the first hit I got on Google, but I ran across some issues for a couple of commit messages so I refactored the regular expression a bit to add some additional validation to the commit messages.

And also extended the error message a bit so you can quickly see the format you should use and what types are valid.

Tests for https://regex101.com are in the CHANGELOG.md file.